### PR TITLE
ci: Exclude stdci tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,8 @@ FLEX_CONTAINER_NAME=ovirt-flexvolume-driver
 PROVISIONER_CONTAINER_NAME=ovirt-volume-provisioner
 
 REGISTRY=rgolangh
-VERSION?=$(shell git describe --tags --always|cut -d "-" -f1)
-RELEASE?=$(shell git describe --tags --always|cut -d "-" -f2- | sed 's/-/_/')
+VERSION?=$(shell git describe --tags --match "v[0-9]*" --always|cut -d "-" -f1)
+RELEASE?=$(shell git describe --tags --match "v[0-9]*" --always|cut -d "-" -f2- | sed 's/-/_/')
 COMMIT=$(shell git rev-parse HEAD)
 BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
 


### PR DESCRIPTION
This repairs the broken failing ci due to jenkins job createing tag on
the repo which later fails rpmbuild because the %release variable
contained something which is not semver

Signed-off-by: Roy Golan <rgolan@redhat.com>