### PR TITLE
ci: Avoid deploying undeeded storage plugin

### DIFF
--- a/automation/ci/integ.ini
+++ b/automation/ci/integ.ini
@@ -43,6 +43,7 @@ openshift_web_console_nodeselector={'region':'infra'}
 openshift_registry_selector='node-registry=true'
 openshift_router_selector='node-router=true'
 
+
 [OSEv3:vars]
 # General variables
 debug_level=2
@@ -57,6 +58,7 @@ openshift_clock_enabled=true
 openshift_debug_level="{{ debug_level }}"
 openshift_master_cluster_method=native
 openshift_node_debug_level="{{ node_debug_level | default(debug_level,true) }}"
+osn_storage_plugin_deps=[]
 
 # Need this for installing flex and provisioner using apb. Not a must though.
 openshift_enable_service_catalog=True


### PR DESCRIPTION
specifically ceph, gluster aren't needed