### PR TITLE
packaging: Change the rpm VERSION-RELEASE schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,8 @@ FLEX_CONTAINER_NAME=ovirt-flexvolume-driver
 PROVISIONER_CONTAINER_NAME=ovirt-volume-provisioner
 
 REGISTRY=rgolangh
-VERSION?=$(shell git describe --tags --match "v[0-9]*" --always|cut -d "-" -f1)
-RELEASE?=$(shell git describe --tags --match "v[0-9]*" --always|cut -d "-" -f2- | sed 's/-/_/')
+VERSION?=$(shell git describe --tags --always --match "v[0-9]*" | awk -F'-' '{print $1 }')
+RELEASE?=$(shell git describe --tags --always --match "v[0-9]*" | awk -F'-' '{print $2 "." $3}')
 COMMIT=$(shell git rev-parse HEAD)
 BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
 


### PR DESCRIPTION
The schema is change to $name-$release-$version and by a change
to the way I extract it is should look like that:

old: ovirt-flexvolume-driver-v0.3.0-45_gXXXXXX
new: ovirt-flexvolume-driver-v0.3.0-45.gXXXXXX