### PR TITLE
packaging: Change the rpm VERSION-RELEASE schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,15 +15,15 @@ FLEX_CONTAINER_NAME=ovirt-flexvolume-driver
 PROVISIONER_CONTAINER_NAME=ovirt-volume-provisioner
 
 REGISTRY=rgolangh
-VERSION?=$(shell git describe --tags --always --match "v[0-9]*" | awk -F'-' '{print $1 }')
-RELEASE?=$(shell git describe --tags --always --match "v[0-9]*" | awk -F'-' '{print $2 "." $3}')
+VERSION?=$(shell git describe --tags --always --match "v[0-9]*" | awk -F'-' '{print $$1 }')
+RELEASE?=$(shell git describe --tags --always --match "v[0-9]*" | awk -F'-' '{print $$2 "." $$3}')
 COMMIT=$(shell git rev-parse HEAD)
 BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
 
 COMMON_ENV=CGO_ENABLED=0 GOOS=linux GOARCH=amd64
 COMMON_GO_BUILD_FLAGS=-a -ldflags '-extldflags "-static"'
 
-TARBALL=ovirt-openshift-extensions-$(VERSION)$(if $(RELEASE),_$(RELEASE)).tar.gz
+TARBALL=ovirt-openshift-extensions-$(VERSION)$(if $(RELEASE),-$(RELEASE)).tar.gz
 
 all: clean deps build test container container-push
 
@@ -102,16 +102,16 @@ rpm:
 	$(MAKE) tarball
 	rpmbuild -tb $(TARBALL) \
 		--define "debug_package %{nil}" \
-		--define "_rpmdir ${ARTIFACT_DIR}" \
-		--define "_version ${VERSION}" \
-		--define "_release ${RELEASE}"
+		--define "_rpmdir $(ARTIFACT_DIR)" \
+		--define "_version $(VERSION)" \
+		--define "_release $(RELEASE)"
 
 srpm:
 	$(MAKE) tarball
 	rpmbuild -ts $(TARBALL) \
 		--define "debug_package %{nil}" \
-		--define "_rpmdir ${ARTIFACT_DIR}" \
-		--define "_version ${VERSION}" \
-		--define "_release ${RELEASE}"
+		--define "_rpmdir $(ARTIFACT_DIR)" \
+		--define "_version $(VERSION)" \
+		--define "_release $(RELEASE)"
 
 .PHONY: build-flex build-provisioner container container-flexdriver container-provisioner container-provisioner-binary container-provisioner-ansible container-push

--- a/ovirt-openshift-extensions.spec
+++ b/ovirt-openshift-extensions.spec
@@ -3,7 +3,7 @@ Version:    %{?_version}
 Release:    %{?_release}%{?dist}
 License:    ASL 2.0
 URL:        http://www.ovirt.org
-Source0:    %{name}-%{version}%{?_release:_%_release}.tar.gz
+Source0:    %{name}-%{version}%{?_release:-%_release}.tar.gz
 Summary:    flexvolume and provisioner
 BuildArch:  x86_64
 


### PR DESCRIPTION
The schema is change to $name-$release-$version and by a change
to the way I extract it is should look like that:

old: ovirt-flexvolume-driver-v0.3.0-45_gXXXXXX
new: ovirt-flexvolume-driver-v0.3.0-45.gXXXXXX