### PR TITLE
Improve the client handling, and re-authenticate when needed

### DIFF
--- a/cmd/ovirt-flexdriver/ovirt-flexdriver.go
+++ b/cmd/ovirt-flexdriver/ovirt-flexdriver.go
@@ -22,7 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/op/go-logging"
+	"github.com/golang/glog"
 	"github.com/ovirt/ovirt-openshift-extensions/internal"
 	"github.com/spf13/viper"
 	"io/ioutil"
@@ -49,12 +49,9 @@ var ovirtVmName string
 
 func main() {
 	s, e := app(os.Args[1:])
-	log, err := logging.NewSyslogBackend("")
-	if err == nil && log != nil {
-		// syslog may not be available, i.e in busybox
-		log.Writer.Info("invoking driver ----- " + strings.Join(os.Args, ","))
-		defer log.Writer.Info("invoking driver ----- " + s)
-	}
+	glog.Infof("invoking with args %s", os.Args)
+	defer glog.Infof("after invoking with args %s", os.Args)
+
 	if e != nil {
 		fmt.Fprint(os.Stderr, e.Error())
 		os.Exit(1)
@@ -120,11 +117,11 @@ func app(args []string) (string, error) {
 		return "", errors.New(usage)
 	}
 
-	bytes, marshalingErr := json.Marshal(result)
+	b, marshalingErr := json.Marshal(result)
 	if marshalingErr != nil {
 		return "", marshalingErr
 	}
-	return string(bytes), err
+	return string(b), err
 }
 
 func initialize() (internal.Response, error) {

--- a/internal/ovirt-mini-api.go
+++ b/internal/ovirt-mini-api.go
@@ -289,7 +289,7 @@ func (ovirt *Ovirt) Post(path string, data interface{}) (string, error) {
 		return "", err
 	}
 	fmt.Println(string(d))
-	resp, err := ovirt.clientDo(http.MethodPost, path, bytes.NewReader(d))
+	resp, err := ovirt.clientDo(http.MethodPost, path, strings.NewReader(string(d)))
 	defer resp.Body.Close()
 
 	if err != nil {

--- a/internal/ovirt-mini-api.go
+++ b/internal/ovirt-mini-api.go
@@ -438,7 +438,6 @@ func (ovirt *Ovirt) clientDo(method string, url string, payload io.Reader) (*htt
 	r.Header.Set("Accept", "application/json")
 	r.Header.Add("Content-Type", "application/json")
 	r.Header.Set("Authorization", "Bearer "+ovirt.token.Value)
-	defer r.Body.Close()
 
 	resp, err := ovirt.client.Do(r)
 

--- a/internal/ovirt-mini-api.go
+++ b/internal/ovirt-mini-api.go
@@ -185,7 +185,7 @@ func (ovirt *Ovirt) Attach(params AttachRequest, vmName string) (Response, error
 
 	return attachResponse, err
 }
-func (ovirt Ovirt) GetDiskByName(diskName string) (DiskResult, error) {
+func (ovirt *Ovirt) GetDiskByName(diskName string) (DiskResult, error) {
 	var diskResult DiskResult
 	r, err := ovirt.Get(fmt.Sprintf("disks?search=name=%s", diskName))
 	if err != nil {
@@ -250,7 +250,7 @@ func (ovirt *Ovirt) CreateDisk(
 	return r, err
 }
 
-func (ovirt Ovirt) Get(path string) ([]byte, error) {
+func (ovirt *Ovirt) Get(path string) ([]byte, error) {
 	request, err := getRequest(fmt.Sprintf("%s/%s", ovirt.Connection.Url, path), ovirt.token.Value)
 	if err != nil {
 		return nil, err
@@ -284,14 +284,14 @@ func translateError(response http.Response) error {
 	return errors.New(response.Status)
 }
 
-func (ovirt Ovirt) Post(path string, data interface{}) (string, error) {
+func (ovirt *Ovirt) Post(path string, data interface{}) (string, error) {
 	d, err := json.Marshal(data)
 	if err != nil {
 		// failed json conversion
 		return "", err
 	}
 	fmt.Println(string(d))
-	request, err := postWithJsonData(&ovirt, path, d)
+	request, err := postWithJsonData(ovirt, path, d)
 	if err != nil {
 		return "", err
 	}
@@ -308,7 +308,7 @@ func (ovirt Ovirt) Post(path string, data interface{}) (string, error) {
 	return string(bytes), err
 }
 
-func (ovirt Ovirt) Delete(path string) ([]byte, error) {
+func (ovirt *Ovirt) Delete(path string) ([]byte, error) {
 	request, err := deleteRequest(fmt.Sprintf("%s/%s", ovirt.Connection.Url, path), ovirt.token.Value)
 	if err != nil {
 		return nil, err

--- a/internal/ovirt-mini-api.go
+++ b/internal/ovirt-mini-api.go
@@ -262,8 +262,8 @@ func (ovirt *Ovirt) Get(path string) ([]byte, error) {
 		return nil, translateError(*resp)
 	}
 
-	bytes, err := ioutil.ReadAll(resp.Body)
-	return bytes, err
+	b, err := ioutil.ReadAll(resp.Body)
+	return b, err
 }
 
 type NotFound struct {
@@ -299,8 +299,8 @@ func (ovirt *Ovirt) Post(path string, data interface{}) (string, error) {
 		return "", errors.New(resp.Status)
 	}
 
-	bytes, err := ioutil.ReadAll(resp.Body)
-	return string(bytes), err
+	b, err := ioutil.ReadAll(resp.Body)
+	return string(b), err
 }
 
 func (ovirt *Ovirt) Delete(path string) ([]byte, error) {
@@ -314,8 +314,8 @@ func (ovirt *Ovirt) Delete(path string) ([]byte, error) {
 		return nil, errors.New(resp.Status)
 	}
 
-	bytes, err := ioutil.ReadAll(resp.Body)
-	return bytes, err
+	b, err := ioutil.ReadAll(resp.Body)
+	return b, err
 }
 
 func (ovirt *Ovirt) GetVM(name string) (VM, error) {
@@ -432,7 +432,6 @@ func fetchToken(ovirtEngineUrl url.URL, username string, password string, client
 }
 
 func (ovirt *Ovirt) clientDo(method string, url string, payload io.Reader) (*http.Response, error) {
-	// TODO log debug the request response
 	url = fmt.Sprintf("%s/%s", ovirt.Connection.Url, url)
 	glog.Infof("calling ovirt api url: %s", url)
 	r, _ := http.NewRequest(method, url, payload)

--- a/internal/ovirt-mini-api_test.go
+++ b/internal/ovirt-mini-api_test.go
@@ -26,6 +26,9 @@ import (
 	"time"
 )
 
+const vmId = "12345678-1234-1234-1234-123456789101"
+const diskId = "d69b93df-7e96-11e8-b3fa-001a4a160100"
+
 func TestLoadConf(t *testing.T) {
 	conf := `
 url=123
@@ -188,6 +191,15 @@ func TestOvirt_Attach(t *testing.T) {
 		"some-vm-id",
 		"disk-uuid",
 		"")
+	if e != nil {
+		t.Errorf(e.Error())
+	}
+}
+
+func TestOvirt_DetachDiskFromVM(t *testing.T) {
+	detachResponse := "{}"
+	api := prepareApi(genericRequestHandlerFunc(detachResponse))
+	e := api.DetachDiskFromVM(vmId, diskId)
 	if e != nil {
 		t.Errorf(e.Error())
 	}


### PR DESCRIPTION
The list of fixes here improves the client handling by;
- DRY
- handle every invocation in a single code path
- added logging

And this lead to handle 401 errors when the ovirt oauth token expired,
which now re-issues a new token.

Fixes: #7