### PR TITLE
flex: Atomically move the flex files

### DIFF
--- a/deployment/ovirt-flexdriver/entrypoint.sh
+++ b/deployment/ovirt-flexdriver/entrypoint.sh
@@ -18,5 +18,12 @@ cp -v /opt/ovirt-flexvolume-driver/ovirt-flexvolume-driver.conf $dir/ovirt~ovirt
 # append per node values to the config
 echo "ovirtVmName=$OVIRT_VM_NAME" >> $dir/ovirt~ovirt-flexvolume-driver/ovirt-flexvolume-driver.conf
 
+# to prevent half-baked initilization do and atomic move into $dir
+tmpdir=$(mktemp -d)
+mv $dir/ovirt~ovirt-flexvolume-driver $tmpdir/
+sleep 5
+mv $tmpdir/ovirt~ovirt-flexvolume-driver $dir
+rmdir $tmpdir
+
 # Now that we have it we can just sleep
 while true;do sleep 1d;done


### PR DESCRIPTION
MOTIVATION 
Kubernetes controller would fail sometimes in initializing the driver
because the 'cp' of the binaries, done by the deployment container,
was still inflight or it lacked the conf file.
This could happen because the controller is constantly monitoring the
plugin folder and gets an event when a file is added.

MODIFICATION
During deploy, use 'mv' command to move the directory with the plugin
into the plugin directory. This ensures an atomic move of all files at
once.

RESULT
The controller initializes the plugin immedialty with no errors.