### PR TITLE
Change rpm versioning, don't include "v"

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,4 +10,5 @@
 !deployment/ovirt-provisioner/deploy.yaml
 !deployment/ovirt-flexdriver/entrypoint.sh
 !**/*.rpm
-!x86_64/*.rpm
+!exported-artifacts
+!x86_64

--- a/automation/build-artifacts.sh
+++ b/automation/build-artifacts.sh
@@ -14,10 +14,6 @@ cd /tmp/build/src/${ORG}/${REPO}
 EXPORTED_ARTIFACTS=exported-artifacts
 mkdir -p $EXPORTED_ARTIFACTS
 
-make rpm ARTIFACT_DIR=$EXPORTED_ARTIFACTS
-
-find $EXPORTED_ARTIFACTS -name "*.rpm" | xargs -I '{}' cp -v '{}' .
-
-make container
+make rpm container ARTIFACT_DIR=$EXPORTED_ARTIFACTS
 make container-push
 make apb_build apb_docker_push

--- a/deployment/ovirt-cloud-provider/container/Dockerfile
+++ b/deployment/ovirt-cloud-provider/container/Dockerfile
@@ -16,10 +16,10 @@ FROM centos:7
 
 LABEL maintainer="Roy Golan, rgolan@redhat.com"
 
-ARG RPM_DIR
 ARG RPM
+ARG RPM_DIR
 
-COPY ${RPM_DIR}/${RPM} /root
+COPY ${RPM_DIR}/${RPM} /root/${RPM}
 
 RUN yum install -y /root/${RPM} && yum clean all
 

--- a/deployment/ovirt-flexdriver/container/Dockerfile
+++ b/deployment/ovirt-flexdriver/container/Dockerfile
@@ -2,9 +2,10 @@ FROM centos:7
 
 LABEL maintainer="Roy Golan, rgolan@redhat.com"
 
-ARG RPM=ovirt-flexvolume-driver*.rpm
+ARG RPM
+ARG RPM_DIR
 
-COPY ${RPM} /root
+COPY ${RPM_DIR}/${RPM} /root/${RPM}
 COPY deployment/ovirt-flexdriver/entrypoint.sh /entrypoint.sh
 
 RUN yum install -y /root/${RPM} && yum clean all

--- a/deployment/ovirt-provisioner/container/Dockerfile
+++ b/deployment/ovirt-provisioner/container/Dockerfile
@@ -16,9 +16,10 @@ FROM centos:7
 
 LABEL maintainer="Roy Golan, rgolan@redhat.com"
 
-ARG RPM=ovirt-provisioner*.rpm
+ARG RPM
+ARG RPM_DIR
 
-COPY ${RPM} /root
+COPY ${RPM_DIR}/${RPM} /root/${RPM}
 
 RUN yum install -y /root/${RPM} && yum clean all
 


### PR DESCRIPTION
All version will now drop the invalid "v" prefix which is used only to
mark a tag as a version tag.

The build and container creation was adjusted and also generelized to be
simpler, and controlled using variables