### PR TITLE
Work with quay.io instead of docker.io

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ PROVISIONER_CONTAINER_NAME=ovirt-volume-provisioner
 AUTOMATION_CONTAINER_NAME=ovirt-openshift-extensions-ci
 CLOUD_PROVIDER_NAME=ovirt-cloud-provider
 
-REGISTRY=rgolangh
+REGISTRY=quay.io/rgolangh
 VERSION?=$(shell git describe --tags --always --match "v[0-9]*" | awk -F'-' '{print substr($$1,2) }')
 RELEASE?=$(shell git describe --tags --always --match "v[0-9]*" | awk -F'-' '{if ($$2 != "") {print $$2 "." $$3} else {print 1}}')
 VERSION_RELEASE=$(VERSION)$(if $(RELEASE),-$(RELEASE))
@@ -91,7 +91,7 @@ container-ci:
 		-f automation/ci/Dockerfile
 
 container-push:
-	@docker login -u rgolangh -p ${DOCKER_BUILDER_API_KEY}
+	@docker login -u rgolangh -p ${QUAY_API_KEY} quay.io
 	docker push $(REGISTRY)/$(FLEX_CONTAINER_NAME):$(VERSION_RELEASE)
 	docker push $(REGISTRY)/$(PROVISIONER_CONTAINER_NAME):$(VERSION_RELEASE)
 	docker push $(REGISTRY)/$(AUTOMATION_CONTAINER_NAME):$(VERSION_RELEASE)
@@ -103,13 +103,13 @@ container-push:
 	docker push $(REGISTRY)/$(CLOUD_PROVIDER_NAME):latest
 
 apb_build:
-	$(MAKE) -C deployment/ovirt-flexvolume-driver-apb/ apb_build
+	$(MAKE) -C deployment/ovirt-flexvolume-driver-apb/ apb_build REGISTRY=$(REGISTRY)
 
 apb_push:
-	$(MAKE) -C deployment/ovirt-flexvolume-driver-apb/ apb_push
+	$(MAKE) -C deployment/ovirt-flexvolume-driver-apb/ apb_push REGISTRY=$(REGISTRY)
 
 apb_docker_push:
-	$(MAKE) -C deployment/ovirt-flexvolume-driver-apb/ docker_push
+	$(MAKE) -C deployment/ovirt-flexvolume-driver-apb/ docker_push REGISTRY=$(REGISTRY)
 
 build: \
 	build-flex \

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ CLOUD_PROVIDER_NAME=ovirt-cloud-provider
 
 REGISTRY=rgolangh
 VERSION?=$(shell git describe --tags --always --match "v[0-9]*" | awk -F'-' '{print substr($$1,2) }')
-RELEASE?=$(shell git describe --tags --always --match "v[0-9]*" | awk -F'-' '$$2 != "" {print $$2 "." $$3}')
+RELEASE?=$(shell git describe --tags --always --match "v[0-9]*" | awk -F'-' '{if ($$2 != "") {print $$2 "." $$3} else {print 1}}')
 VERSION_RELEASE=$(VERSION)$(if $(RELEASE),-$(RELEASE))
 
 COMMIT=$(shell git rev-parse HEAD)

--- a/README.md
+++ b/README.md
@@ -3,6 +3,13 @@
 [![Build Status](http://jenkins.ovirt.org/buildStatus/icon?job=oVirt_ovirt-openshift-extensions_standard-on-ghpush)](http://jenkins.ovirt.org/job/oVirt_ovirt-openshift-extensions_standard-on-ghpush/)
 [![Go Report Card](https://goreportcard.com/badge/github.com/ovirt/ovirt-openshift-extensions)](https://goreportcard.com/report/github.com/ovirt/ovirt-openshift-extensions)
 
+| container image | status    | 
+| :---            | :---      |
+|ovirt-flexvolume-driver |[![ovirt-flexvolume-driver](https://quay.io/repository/rgolangh/ovirt-flexvolume-driver/status)](https://quay.io/repository/rgolangh/ovirt-flexvolume-driver/status) |
+|ovirt-volume-provisioner|[![ovirt-volume-provisioner](https://quay.io/repository/rgolangh/ovirt-volume-provisioner/status)](https://quay.io/repository/rgolangh/ovirt-volume-provisioner/status) |
+|ovirt-cloud-provider    |[![ovirt-cloud-provider](https://quay.io/repository/rgolangh/ovirt-cloud-provider/status)](https://quay.io/repository/rgolangh/ovirt-cloud-provider/status) |
+|ovirt-openshift-extensions-ci    |[![ovirt-openshift-extensions-ci](https://quay.io/repository/rgolangh/ovirt-openshift-extensions-ci/status)](https://quay.io/repository/rgolangh/ovirt-openshift-extensions-ci/status) |
+
 ## Purpose
 The project purpose is to the best out of openshift installation on top of oVirt.
 It's main components are:
@@ -67,7 +74,7 @@ From the repo:
     --rm \
     --net=host \
     -v $HOME/.kube:/opt/apb/.kube:z \
-    -u $UID docker.io/rgolangh/ovirt-flexvolume-driver-apb \
+    -u $UID quay.io/rgolangh/ovirt-flexvolume-driver-apb \
     provision \
     -e admin_password=$OCP_PASS -e admin_user=$OCP_USER \
     -e cluster=openshift -e namespace=default \

--- a/automation/build-artifacts.environment.yaml
+++ b/automation/build-artifacts.environment.yaml
@@ -3,3 +3,10 @@
     secretKeyRef:
         name: 'docker_api_key'
         key: 'key'
+
+- name: QUAY_API_KEY
+  valueFrom:
+    secretKeyRef:
+      name: 'QUAY_API_KEY'
+      key: 'quai_api_key'
+

--- a/automation/ci/flex_deployer_job.yaml
+++ b/automation/ci/flex_deployer_job.yaml
@@ -20,7 +20,7 @@ spec:
           value: "developer"
         - name: ADMIN_PASS
           value: "developer"
-        image: docker.io/rgolangh/ovirt-flexvolume-driver-apb
+        image: quay.io/rgolangh/ovirt-flexvolume-driver-apb
         args: ["provision", "-e", "admin_user=$(ADMIN_USER)", "-e", "admin_password=$(ADMIN_PASS)","-e", "cluster=openshift","-e", "namespace=default","-e", "engine_password=$(ENGINE_PASS)","-e", "engine_url=$(ENGINE_URL)","-e", "engine_username=$(ENGINE_USER)"]
         imagePullPolicy: Always
         name: ovirt-flexvolume-deployer

--- a/deployment/example/ovirt-provisioner-pod.yaml
+++ b/deployment/example/ovirt-provisioner-pod.yaml
@@ -7,7 +7,7 @@ spec:
   serviceAccount: ovirt-provisioner
   containers:
   - name: ovirt-provisioner
-    image: rgolangh/ovirt-provisioner:v0.2.0
+    image: quay.io/rgolangh/ovirt-provisioner
     securityContext:
     imagePullPolicy: "IfNotPresent"
     volumeMounts:

--- a/deployment/ovirt-cloud-controller-descriptor.yaml
+++ b/deployment/ovirt-cloud-controller-descriptor.yaml
@@ -40,7 +40,7 @@ spec:
         # for in-tree providers we use gcr.io/google_containers/cloud-controller-manager
         # this can be replaced with any other image for out-of-tree providers
         #image: gcr.io/google_containers/cloud-controller-manager:v1.8.0
-        image: docker.io/rgolangh/ovirt-cloud-controller
+        image: quay.io/rgolangh/ovirt-cloud-controller
         command:
         - /usr/local/bin/ovirt-cloud-controller
         - --cloud-provider=ovirt-cloud-provider

--- a/deployment/ovirt-flexvolume-driver-apb/Makefile
+++ b/deployment/ovirt-flexvolume-driver-apb/Makefile
@@ -1,5 +1,5 @@
-DOCKERHOST = docker.io
-DOCKERORG = rgolangh
+# set the registry from the main Makefile under the root of the repo
+REGISTRY= 
 IMAGENAME = ovirt-flexvolume-driver-apb
 TAG = latest
 USER=$(shell id -u)
@@ -11,11 +11,11 @@ build_and_push: apb_build docker_push apb_push
 .PHONY: apb_build
 apb_build:
 	docker run --rm --privileged -v $(PWD):/mnt:z -v /var/run/docker.sock:/var/run/docker.sock -u ${USER} docker.io/ansibleplaybookbundle/apb-tools:latest prepare
-	docker build -t $(DOCKERHOST)/$(DOCKERORG)/$(IMAGENAME):$(TAG) .
+	docker build -t $(REGISTRY)/$(IMAGENAME):$(TAG) .
 
 .PHONY: docker_push
 docker_push:
-	docker push $(DOCKERHOST)/$(DOCKERORG)/$(IMAGENAME):$(TAG)
+	docker push $(REGISTRY)/$(IMAGENAME):$(TAG)
 
 .PHONY: apb_push
 apb_push:

--- a/deployment/ovirt-flexvolume-driver-apb/roles/provision-ovirt-flexvolume-driver-apb/tasks/main.yml
+++ b/deployment/ovirt-flexvolume-driver-apb/roles/provision-ovirt-flexvolume-driver-apb/tasks/main.yml
@@ -42,7 +42,7 @@
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
     containers:
-    - image: docker.io/rgolangh/ovirt-flexvolume-driver
+    - image: quay.io/rgolangh/ovirt-flexvolume-driver
       name: ovirt-flexvolume-driver
       securityContext:
           privileged: true
@@ -144,7 +144,7 @@
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
     containers:
-      - image: rgolangh/ovirt-volume-provisioner
+      - image: quay.io/rgolangh/ovirt-volume-provisioner
         name: ovirt-volume-provisioner
         volumeMounts:
           - name: config-volume

--- a/deployment/ovirt-provisioner/ovirt-provisioner-manifest.yaml.j2
+++ b/deployment/ovirt-provisioner/ovirt-provisioner-manifest.yaml.j2
@@ -83,7 +83,7 @@ spec:
   serviceAccount: ovirt-provisioner
   containers:
   - name: ovirt-provisioner
-    image: rgolangh/ovirt-provisioner:{{ provisioner_version }}
+    image: quay.io/rgolangh/ovirt-provisioner:{{ provisioner_version }}
     securityContext:
     imagePullPolicy: "IfNotPresent"
     volumeMounts:


### PR DESCRIPTION
Replacing the proprierary docker.io with the soon to be open-sourced
quay.io registry.

The repositories are all under 'rgolangh' user(same as in docker.io), and this might change in
the future, when/if we will have proper CI support that will push all to
'ovirt' organization.

From this patch on the container images on docker.io are no longer valid
and may be deleted any time in the future.

Fixes: #55