### PR TITLE
ci: Install okd 3.11

### DIFF
--- a/automation/ci/Dockerfile
+++ b/automation/ci/Dockerfile
@@ -30,5 +30,5 @@ ADD deploy_flex.yaml  /root/deploy_flex.yaml
 ADD flex_deployer_job.yaml  /root/flex_deployer_job.yaml
 
 WORKDIR /root
-RUN git clone --branch release-3.10 https://github.com/openshift/openshift-ansible --depth 1
+RUN git clone --branch release-3.11 https://github.com/openshift/openshift-ansible --depth 1
 ENTRYPOINT ansible-playbook -i integ.ini site.yaml


### PR DESCRIPTION
The 3.10 installation looks broken and its anyway the time to move to
3.11. Code wise the components are compiled against k8s client for 3.11