### PR TITLE
Revert "ci: Install okd 3.11"

### DIFF
--- a/automation/ci/Dockerfile
+++ b/automation/ci/Dockerfile
@@ -30,5 +30,5 @@ ADD deploy_flex.yaml  /root/deploy_flex.yaml
 ADD flex_deployer_job.yaml  /root/flex_deployer_job.yaml
 
 WORKDIR /root
-RUN git clone --branch release-3.11 https://github.com/openshift/openshift-ansible --depth 1
+RUN git clone --branch release-3.10 https://github.com/openshift/openshift-ansible --depth 1
 ENTRYPOINT ansible-playbook -i integ.ini site.yaml


### PR DESCRIPTION
This reverts commit d17dca10361fc7bd6f294e2fa79d9397b5699cfd.

The 3.11 packages are not available yet under
http://mirror.centos.org/centos/7/paas/x86_64/openshift-origin/