### PR TITLE
make: generify targets and cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,9 @@
 *.ca
 *.retry
 deployment/*.retry
-/ovirt-flexdriver
+/ovirt-flexvolume-driver
 /ovirt-flexdriver.conf
-/ovirt-provisioner
+/ovirt-volume-provisioner
 /ovirt-cloud-provider
 /ovirt-api.conf
 deployment/container/ovirt-provisioner

--- a/Makefile
+++ b/Makefile
@@ -9,13 +9,6 @@ GODEP=dep
 PREFIX=.
 ARTIFACT_DIR ?= .
 
-FLEX_DRIVER_BINARY_NAME=ovirt-flexvolume-driver
-PROVISIONER_BINARY_NAME=ovirt-volume-provisioner
-FLEX_CONTAINER_NAME=ovirt-flexvolume-driver
-PROVISIONER_CONTAINER_NAME=ovirt-volume-provisioner
-AUTOMATION_CONTAINER_NAME=ovirt-openshift-extensions-ci
-CLOUD_PROVIDER_NAME=ovirt-cloud-provider
-
 REGISTRY=quay.io/rgolangh
 VERSION?=$(shell git describe --tags --always --match "v[0-9]*" | awk -F'-' '{print substr($$1,2) }')
 RELEASE?=$(shell git describe --tags --always --match "v[0-9]*" | awk -F'-' '{if ($$2 != "") {print $$2 "." $$3} else {print 1}}')
@@ -31,67 +24,47 @@ TARBALL=ovirt-openshift-extensions-$(VERSION_RELEASE).tar.gz
 
 all: clean deps build test container container-push
 
-build-flex:
-	$(COMMON_ENV) $(GOBUILD) \
-	$(COMMON_GO_BUILD_FLAGS) \
-	-o $(PREFIX)/$(FLEX_DRIVER_BINARY_NAME) \
-	-v cmd/$(FLEX_DRIVER_BINARY_NAME)/*.go
-
-build-provisioner:
-	$(COMMON_ENV) $(GOBUILD) \
-	$(COMMON_GO_BUILD_FLAGS) \
-	-o $(PREFIX)/$(PROVISIONER_BINARY_NAME) \
-	-v cmd/$(PROVISIONER_BINARY_NAME)/*.go
-
-build-cloud-provider:
-	$(COMMON_ENV) $(GOBUILD) \
-	$(COMMON_GO_BUILD_FLAGS) \
-	-o $(PREFIX)/$(CLOUD_PROVIDER_NAME) \
-	-v cmd/$(CLOUD_PROVIDER_NAME)/*.go
-
-containers = \
+binaries = \
 	ovirt-flexvolume-driver \
 	ovirt-volume-provisioner \
-	ovirt-cloud-provider \
+	ovirt-cloud-provider
+
+containers = \
+	$(binaries) \
 	ovirt-openshift-extensions-ci
 
-$(containers): tarball
+$(binaries):
+	$(COMMON_ENV) $(GOBUILD) \
+    	$(COMMON_GO_BUILD_FLAGS) \
+    	-o $(PREFIX)/$@ \
+    	-v cmd/$@/*.go
+
+
 container-%: DIR=.
-container-%: DOCKERFILE=deployment/$</container/Dockerfile
+container-%: DOCKERFILE=deployment/$*/container/Dockerfile
 container-ovirt-openshift-extensions-ci: DIR=automation/ci
 container-ovirt-openshift-extensions-ci: DOCKERFILE=$(DIR)/Dockerfile
 
-container-%: %
+container-%: tarball
 	docker build \
-		-t $(REGISTRY)/$<:$(VERSION_RELEASE) \
-		-t $(REGISTRY)/$<:latest \
+		-t $(REGISTRY)/$*:$(VERSION_RELEASE) \
+		-t $(REGISTRY)/$*:latest \
 		--build-arg VERSION=$(VERSION) \
 		--build-arg RELEASE=$(RELEASE) \
 		-f $(DOCKERFILE) \
 		$(DIR)
 
-build-containers: $(addprefix container-, $(containers))
-push-containers: $(addprefix container-push-, $(containers))
-
-container-push-%: %
+container-push-%:
 	@docker login -u rgolangh -p ${QUAY_API_KEY} quay.io
-	docker push $(REGISTRY)/$<:$(VERSION_RELEASE)
-	docker push $(REGISTRY)/$<:latest
-	echo "$(REGISTRY)/$<:$(VERSION_RELEASE)" >> containers-artifacts.list
+	docker push $(REGISTRY)/$*:$(VERSION_RELEASE)
+	docker push $(REGISTRY)/$*:latest
+	echo "$(REGISTRY)/$*:$(VERSION_RELEASE)" >> containers-artifacts.list
 
-apb_build:
-	$(MAKE) -C deployment/ovirt-flexvolume-driver-apb/ apb_build REGISTRY=$(REGISTRY)
+build: $(binaries)
 
-apb_push:
-	$(MAKE) -C deployment/ovirt-flexvolume-driver-apb/ apb_push REGISTRY=$(REGISTRY)
+build-containers: $(addprefix container-, $(containers))
 
-apb_docker_push:
-	$(MAKE) -C deployment/ovirt-flexvolume-driver-apb/ docker_push REGISTRY=$(REGISTRY)
-
-build: \
-	build-flex \
-	build-provisioner \
-	build-cloud-provider
+push-containers: $(addprefix container-push-, $(containers))
 
 test:
 	$(GOTEST) -v ./...
@@ -104,9 +77,17 @@ deps:
 	dep ensure --update
 
 tarball: $(TARBALL)
-	echo making tar
 
 $(TARBALL):
 	/bin/git archive --format=tar.gz HEAD > $(TARBALL)
 
-.PHONY: build-flex build-provisioner build-cloud-provider container container-flexdriver container-provisioner container-cloud-provider container-ci container-push
+apb_build:
+	$(MAKE) -C deployment/ovirt-flexvolume-driver-apb/ apb_build REGISTRY=$(REGISTRY)
+
+apb_push:
+	$(MAKE) -C deployment/ovirt-flexvolume-driver-apb/ apb_push REGISTRY=$(REGISTRY)
+
+apb_docker_push:
+	$(MAKE) -C deployment/ovirt-flexvolume-driver-apb/ docker_push REGISTRY=$(REGISTRY)
+
+.PHONY: all tarball test build build-containers push-containers apb_build apb_docker_push apb_push

--- a/automation/ci/Dockerfile
+++ b/automation/ci/Dockerfile
@@ -30,5 +30,5 @@ ADD deploy_flex.yaml  /root/deploy_flex.yaml
 ADD flex_deployer_job.yaml  /root/flex_deployer_job.yaml
 
 WORKDIR /root
-RUN git clone --branch release-3.10 https://github.com/openshift/openshift-ansible --depth 1
+RUN git clone --branch release-3.11 https://github.com/openshift/openshift-ansible --depth 1
 ENTRYPOINT ansible-playbook -i integ.ini site.yaml

--- a/automation/ci/integ.ini
+++ b/automation/ci/integ.ini
@@ -37,6 +37,7 @@ openshift_router_selector='node-router=true'
 # General variables
 debug_level=2
 containerized=False
+openshift_release="{{ lookup('env', 'target_branch')|default('3.10') }}"
 ansible_ssh_user=root
 os_firewall_use_firewalld=True
 openshift_deployment_type=origin

--- a/automation/ci/vars.yaml
+++ b/automation/ci/vars.yaml
@@ -67,6 +67,7 @@ cloud_init_script_master: |
       gpgcheck: false
     packages:
     - ovirt-guest-agent
+    - centos-release-openshift-origin
   runcmd:
     - systemctl enable ovirt-guest-agent
     - systemctl start ovirt-guest-agent

--- a/deployment/ovirt-cloud-provider/container/Dockerfile
+++ b/deployment/ovirt-cloud-provider/container/Dockerfile
@@ -24,7 +24,7 @@ WORKDIR /root/go/src/github.com/ovirt/ovirt-openshift-extensions
 ADD ovirt-openshift-extensions-$VERSION-$RELEASE.tar.gz .
 
 RUN yum install -y golang make
-RUN make build-cloud-provider
+RUN make ovirt-cloud-provider
 
 #TODO use multi-stage when buildah runs in mock or docker 1.17 is available
 RUN cp -v ovirt-cloud-provider /usr/bin

--- a/deployment/ovirt-cloud-provider/container/Dockerfile
+++ b/deployment/ovirt-cloud-provider/container/Dockerfile
@@ -12,12 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM centos:7
-
-LABEL maintainer="Roy Golan, rgolan@redhat.com"
+FROM centos:7.5.1804
 
 ARG VERSION
 ARG RELEASE
+
+LABEL   com.redhat.component="ovirt-openshift-extensions" \
+        name="ovirt-cloud-provider" \
+        version="$VERSION" \
+        release="$RELEASE" \
+        architecture="x86_64" \
+        summary="ovirt-cloud-provider for openshift, for a deployment on top of ovirt" \
+        maintainer="Roy Golan <rgolan@redhat.com>"
 
 RUN mkdir -p /root/go/src/github.com/ovirt/ovirt-openshift-extensions
 WORKDIR /root/go/src/github.com/ovirt/ovirt-openshift-extensions

--- a/deployment/ovirt-flexvolume-driver/container/Dockerfile
+++ b/deployment/ovirt-flexvolume-driver/container/Dockerfile
@@ -24,7 +24,7 @@ WORKDIR /root/go/src/github.com/ovirt/ovirt-openshift-extensions
 ADD ovirt-openshift-extensions-$VERSION-$RELEASE.tar.gz .
 
 RUN yum install -y golang make
-RUN make build-flex
+RUN make ovirt-flexvolume-driver
 
 #TODO use multi-stage when buildah runs in mock or docker 1.17 is available
 RUN cp -v ovirt-flexvolume-driver /usr/bin/

--- a/deployment/ovirt-flexvolume-driver/container/Dockerfile
+++ b/deployment/ovirt-flexvolume-driver/container/Dockerfile
@@ -12,12 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM centos:7
-
-LABEL maintainer="Roy Golan, rgolan@redhat.com"
+FROM centos:7.5.1804
 
 ARG VERSION
 ARG RELEASE
+
+LABEL   com.redhat.component="ovirt-openshift-extensions" \
+        name="ovirt-flexvolume-driver" \
+        version="$VERSION" \
+        release="$RELEASE" \
+        architecture="x86_64" \
+        summary="ovirt-flexvolume-driver for openshift, for dynamic volume provisioning" \
+        maintainer="Roy Golan <rgolan@redhat.com>"
 
 RUN mkdir -p /root/go/src/github.com/ovirt/ovirt-openshift-extensions
 WORKDIR /root/go/src/github.com/ovirt/ovirt-openshift-extensions

--- a/deployment/ovirt-volume-provisioner/container/Dockerfile
+++ b/deployment/ovirt-volume-provisioner/container/Dockerfile
@@ -24,7 +24,7 @@ WORKDIR /root/go/src/github.com/ovirt/ovirt-openshift-extensions
 ADD ovirt-openshift-extensions-$VERSION-$RELEASE.tar.gz .
 
 RUN yum install -y golang make
-RUN make build-provisioner
+RUN make ovirt-volume-provisioner
 
 #TODO use multi-stage when buildah runs in mock or docker 1.17 is available
 RUN cp -v ovirt-volume-provisioner /usr/bin

--- a/deployment/ovirt-volume-provisioner/container/Dockerfile
+++ b/deployment/ovirt-volume-provisioner/container/Dockerfile
@@ -12,12 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM centos:7
-
-LABEL maintainer="Roy Golan, rgolan@redhat.com"
+FROM centos:7.5.1804
 
 ARG VERSION
 ARG RELEASE
+
+LABEL   com.redhat.component="ovirt-openshift-extensions" \
+        name="ovirt-volume-provisioner" \
+        version="$VERSION" \
+        release="$RELEASE" \
+        architecture="x86_64" \
+        summary="ovirt-volume-provisioner for openshift, for dynamic volume provisioning" \
+        maintainer="Roy Golan <rgolan@redhat.com>"
 
 RUN mkdir -p /root/go/src/github.com/ovirt/ovirt-openshift-extensions
 WORKDIR /root/go/src/github.com/ovirt/ovirt-openshift-extensions


### PR DESCRIPTION
The Makefile is even more generic now, clean, and easy to interact with
and extend.

The main targets are: build, build-containers, push-containers