### PR TITLE
ovirt-api: proper handling of 302 errors

### DIFF
--- a/internal/ovirt-mini-api.go
+++ b/internal/ovirt-mini-api.go
@@ -420,11 +420,12 @@ func fetchToken(ovirtEngineUrl url.URL, username string, password string, client
 	req.Header.Add("Accept", "application/json")
 
 	resp, err := client.Do(req)
-	defer resp.Body.Close()
 
 	if err != nil {
 		return Token{}, err
 	}
+
+	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
 		return Token{}, fmt.Errorf("fail to login and fetching token %s", resp.Status)

--- a/internal/ovirt-mini-api_test.go
+++ b/internal/ovirt-mini-api_test.go
@@ -90,6 +90,29 @@ func TestFetchToken(t *testing.T) {
 	}
 }
 
+func TestFailedFetchToken_move302(t *testing.T) {
+	api := CreateMockOvirtClient(func(writer http.ResponseWriter, request *http.Request) {
+		writer.WriteHeader(302)
+	})
+
+	err := api.Authenticate()
+	if err == nil {
+		t.Fatal("should fail with error")
+	}
+}
+
+func TestFailedFetchToken_404(t *testing.T) {
+	api := CreateMockOvirtClient(func(writer http.ResponseWriter, request *http.Request) {
+		writer.WriteHeader(404)
+	})
+
+	err := api.Authenticate()
+	t.Logf("error is %s", err)
+	if err == nil {
+		t.Fatal("should fail with error")
+	}
+}
+
 func CreateMockOvirtClient(handler http.HandlerFunc) Ovirt {
 	ts := httptest.NewServer(handler)
 	return Ovirt{


### PR DESCRIPTION
302 errors returns nil responses, that panics when trying to close the
response body in defer.