### PR TITLE
ovirt-api: Fix and upgrade software stack

### DIFF
--- a/cmd/ovirt-cloud-provider/ovirt-cloud-provider_test.go
+++ b/cmd/ovirt-cloud-provider/ovirt-cloud-provider_test.go
@@ -231,10 +231,6 @@ func (MockApi) DetachDiskFromVM(vmId string, diskId string) error {
 	panic("implement me")
 }
 
-func (MockApi) Attach(params internal.AttachRequest, nodeName string) (internal.Response, error) {
-	panic("implement me")
-}
-
 func (MockApi) GetDiskByName(diskName string) (internal.DiskResult, error) {
 	panic("implement me")
 }

--- a/deployment/ovirt-cloud-provider/container/Dockerfile
+++ b/deployment/ovirt-cloud-provider/container/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM centos:7.5.1804
+FROM centos:7.6.1810
 
 ARG VERSION
 ARG RELEASE
@@ -29,7 +29,10 @@ RUN mkdir -p /root/go/src/github.com/ovirt/ovirt-openshift-extensions
 WORKDIR /root/go/src/github.com/ovirt/ovirt-openshift-extensions
 ADD ovirt-openshift-extensions-$VERSION-$RELEASE.tar.gz .
 
-RUN yum install -y golang make
+RUN yum install -y epel-release --enablerepo=extras && \
+    yum install -y --enablerepo=extras golang make &&  \
+    yum clean all && rm -rf /var/cache/yum
+
 RUN make ovirt-cloud-provider
 
 #TODO use multi-stage when buildah runs in mock or docker 1.17 is available

--- a/deployment/ovirt-flexvolume-driver/container/Dockerfile
+++ b/deployment/ovirt-flexvolume-driver/container/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM centos:7.5.1804
+FROM centos:7.6.1810
 
 ARG VERSION
 ARG RELEASE
@@ -29,7 +29,10 @@ RUN mkdir -p /root/go/src/github.com/ovirt/ovirt-openshift-extensions
 WORKDIR /root/go/src/github.com/ovirt/ovirt-openshift-extensions
 ADD ovirt-openshift-extensions-$VERSION-$RELEASE.tar.gz .
 
-RUN yum install -y golang make
+RUN yum install -y epel-release --enablerepo=extras && \
+    yum install -y --enablerepo=extras golang make &&  \
+    yum clean all && rm -rf /var/cache/yum
+
 RUN make ovirt-flexvolume-driver
 
 #TODO use multi-stage when buildah runs in mock or docker 1.17 is available

--- a/deployment/ovirt-volume-provisioner/container/Dockerfile
+++ b/deployment/ovirt-volume-provisioner/container/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM centos:7.5.1804
+FROM centos:7.6.1810
 
 ARG VERSION
 ARG RELEASE
@@ -29,7 +29,10 @@ RUN mkdir -p /root/go/src/github.com/ovirt/ovirt-openshift-extensions
 WORKDIR /root/go/src/github.com/ovirt/ovirt-openshift-extensions
 ADD ovirt-openshift-extensions-$VERSION-$RELEASE.tar.gz .
 
-RUN yum install -y golang make
+RUN yum install -y epel-release --enablerepo=extras && \
+    yum install -y --enablerepo=extras golang make &&  \
+    yum clean all && rm -rf /var/cache/yum
+
 RUN make ovirt-volume-provisioner
 
 #TODO use multi-stage when buildah runs in mock or docker 1.17 is available

--- a/internal/definitions.go
+++ b/internal/definitions.go
@@ -45,7 +45,6 @@ type OvirtApi interface {
 	GetDiskAttachment(vmId, diskId string) (DiskAttachment, error)
 	GetDiskAttachments(vmId string) ([]DiskAttachment, error)
 	DetachDiskFromVM(vmId string, diskId string) error
-	Attach(params AttachRequest, nodeName string) (Response, error)
 	GetDiskByName(diskName string) (DiskResult, error)
 	CreateUnattachedDisk(diskName string, storageDomainName string, sizeIbBytes int64, readOnly bool, diskFormat string) (Disk, error)
 	CreateDisk(


### PR DESCRIPTION
Upgrade to centos 7.6
Upgrade to golang 1.11
Fix broken compilation to partial removel of Attach method
implementation (always send pull-request to run CI!!!)