### PR TITLE
Proper thin/thick provisioing behaviour

### DIFF
--- a/automation/ci/deploy_flex.yaml
+++ b/automation/ci/deploy_flex.yaml
@@ -44,7 +44,7 @@
       register: result
       until: result.stdout == "Running"
       retries: 60
-      delay: 5
+      delay: 10
 
     - name: verify the test pod sees the flex mounted file system
       shell: oc exec -it testpodwithflex ls /opt

--- a/cmd/ovirt-cloud-provider/ovirt-cloud-provider_test.go
+++ b/cmd/ovirt-cloud-provider/ovirt-cloud-provider_test.go
@@ -234,7 +234,7 @@ func (MockApi) GetDiskByName(diskName string) (internal.DiskResult, error) {
 	panic("implement me")
 }
 
-func (MockApi) CreateUnattachedDisk(diskName string, storageDomainName string, sizeIbBytes int64, readOnly bool, diskFormat string) (internal.Disk, error) {
+func (MockApi) CreateUnattachedDisk(diskName string, storageDomainName string, sizeIbBytes int64, readOnly bool, thinProvisioning bool) (internal.Disk, error) {
 	panic("implement me")
 }
 

--- a/deployment/example/ovirt-storage-class.yaml
+++ b/deployment/example/ovirt-storage-class.yaml
@@ -4,12 +4,11 @@ metadata:
   name: ovirt
 provisioner: ovirt-volume-provisioner
 parameters:
-  type: io1
-  iopsPerGB: "10"
+  # oVirt target storage domain name for the created disks.
   ovirtStorageDomain: "nfs"
-  # specifing a disk format is a must and depends on
-  # the type of the domain - block-storage(iscsi/FC) or file(NFS/gluster...)
-  ovirtDiskFormat: "cow"
+  # Specify thin provisioning or not (default true)
+  # The provisioner will figure out the disk type for you
+  ovirtThinProvisioning: true
+  # The file system to create on the disk prior to attaching it to the container.
+  # If the filesystem already exists, don't re-recreate.
   fsType: ext4
-
-

--- a/internal/definitions.go
+++ b/internal/definitions.go
@@ -46,7 +46,7 @@ type OvirtApi interface {
 	GetDiskAttachments(vmId string) ([]DiskAttachment, error)
 	DetachDiskFromVM(vmId string, diskId string) error
 	GetDiskByName(diskName string) (DiskResult, error)
-	CreateUnattachedDisk(diskName string, storageDomainName string, sizeIbBytes int64, readOnly bool, diskFormat string) (Disk, error)
+	CreateUnattachedDisk(diskName string, storageDomainName string, sizeIbBytes int64, readOnly bool, thinProvisioning bool) (Disk, error)
 	CreateDisk(
 		diskName string,
 		storageDomainName string,

--- a/internal/types.go
+++ b/internal/types.go
@@ -16,6 +16,13 @@ limitations under the License.
 
 package internal
 
+import "errors"
+
+// ovirt api common errors
+var (
+	ErrNotExist = errors.New("resource does not exists")
+)
+
 type DiskAttachment struct {
 	Id          string `json:"id,omitempty"`
 	Bootable    bool   `json:"bootable,string"`
@@ -31,6 +38,7 @@ type DiskAttachmentResult struct {
 }
 
 type DiskFormat string
+type Sparse		bool
 
 type Disk struct {
 	Id              string         `json:"id,omitempty"`
@@ -40,6 +48,8 @@ type Disk struct {
 	Status          string         `json:"status,omitempty"`
 	Format          DiskFormat     `json:"format"`
 	StorageDomains  StorageDomains `json:"storage_domains"`
+	Sparse  		Sparse         `json:"sparse"`
+
 }
 
 type DiskResult struct {
@@ -52,6 +62,7 @@ type StorageDomains struct {
 
 type StorageDomain struct {
 	Name string `json:"name"`
+	Storage struct{  Type string `json:"type"`} `json:"storage"`
 }
 
 type VM struct {


### PR DESCRIPTION
Motivation
The provisioner should allow thin/thick provisioning of disk, according
to what ovirt supports. Till now the support was through
'ovirtDiskFormat' parameter, and this is now dropped.
If a thin or thick disk is wanted, is is expected using a flag,
ovirtThinProvisioning, true by default.

Modification
- 'ovirtDiskFormat' parameter is dropped from the storage class
- 'ovirtDiskThinProvisioning' parameter, default true is expected.
The api will set the underlying disk format (raw/cow) according to the
storage domain tyep (iscsi/fc/nfs/cluster)

Result
For a thin provision disk, either don't pass nothing or
ovirtDiskThinProvioning=true
If the target ovirt storage domain is ISCSI or FC the disk format type
will be 'cow' and the sparse=true
If the target domain is NFS or Gluster the format is 'raw' and
sparse=true
For ovirtDiskProvisioning=false then the disk format is 'raw' and
sparse=false

fixes: #93