### PR TITLE
flex:Query the api server to extract node info

### DIFF
--- a/cmd/ovirt-flexvolume-driver/kube-client.go
+++ b/cmd/ovirt-flexvolume-driver/kube-client.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2019 oVirt-maintainers
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Note: the example only works with the code within the same release/branch.
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/kubernetes/pkg/util/file"
+)
+
+func getSystemUUIDByNodeName(nodeName string) (string, error) {
+	nodes, e := getKubeNodes()
+	if e != nil {
+		return "", e
+	}
+	for _, n := range nodes {
+		if n.Name == nodeName {
+			return n.Status.NodeInfo.SystemUUID, nil
+		}
+	}
+	return "", fmt.Errorf("node name %s was not found", nodeName)
+}
+
+func getKubeNodes() ([]v1.Node, error) {
+	kubeconfig, err := locateKubeConfig()
+
+	if err != nil {
+		return nil, err
+	}
+
+	// use the current context in kubeconfig
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+
+	// create the clientset
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	nodes, err := clientset.CoreV1().Nodes().List(metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	return nodes.Items, nil
+}
+
+func locateKubeConfig() (string, error) {
+	defaultKubeConfig := "/etc/origin/master/admin.kubeconfig"
+	var err = os.ErrNotExist
+	var ok bool
+	if ok, err = file.FileOrSymlinkExists(defaultKubeConfig); ok {
+		return defaultKubeConfig, nil
+	}
+
+	if k := os.Getenv("KUBECONFIG"); k != "" {
+		if ok, err = file.FileOrSymlinkExists(k); ok {
+			return k, nil
+		}
+	}
+
+	if home := homeDir(); home != "" {
+		kubeconfig := filepath.Join(home, ".kube", "config")
+		if ok, err = file.FileOrSymlinkExists(kubeconfig); ok {
+			return kubeconfig, nil
+		}
+	}
+
+	return "", err
+}
+
+func homeDir() string {
+	if h := os.Getenv("HOME"); h != "" {
+		return h
+	}
+	return os.Getenv("USERPROFILE") // windows
+}

--- a/cmd/ovirt-flexvolume-driver/ovirt-flexdriver.go
+++ b/cmd/ovirt-flexvolume-driver/ovirt-flexdriver.go
@@ -47,6 +47,11 @@ const usage = `Usage:
 `
 
 var driverConfigFile string
+
+/*
+Use the vmId extracted from the OS only for api interaction which doesn't include the nodeName.
+For example Attach/Detach uses the node name, which waitForAttach does not.
+ */
 var ovirtVmId string
 
 func main() {
@@ -184,7 +189,12 @@ func Attach(jsonOpts string, nodeName string) (internal.Response, error) {
 		return internal.FailedResponse, e
 	}
 
-	vm, err := ovirt.GetVMById(ovirtVmId)
+	vmId, err := getSystemUUIDByNodeName(nodeName)
+	if err != nil {
+		return internal.FailedResponseFromError(err), err
+	}
+
+	vm, err := ovirt.GetVMById(vmId)
 	// 0. validation - Attach size is legal?
 	// 1. query if the disk exists
 	// 2. if it exist, is it already attached to a VM (perhaps a detach is in progress)
@@ -238,7 +248,12 @@ func IsAttached(jsonOpts string, nodeName string) (internal.Response, error) {
 		return internal.FailedResponse, e
 	}
 
-	vm, err := ovirt.GetVMById(ovirtVmId)
+	vmId, err := getSystemUUIDByNodeName(nodeName)
+	if err != nil {
+		return internal.FailedResponseFromError(err), err
+	}
+
+	vm, err := ovirt.GetVMById(vmId)
 	if err != nil {
 		return internal.FailedResponseFromError(err), err
 	}
@@ -285,7 +300,12 @@ func Detach(volumeName string, nodeName string) (internal.Response, error) {
 
 	ovirtDiskName := fromk8sNameToOvirt(volumeName)
 
-	vm, err := ovirt.GetVMById(ovirtVmId)
+	vmId, err := getSystemUUIDByNodeName(nodeName)
+	if err != nil {
+		return internal.FailedResponseFromError(err), err
+	}
+
+	vm, err := ovirt.GetVMById(vmId)
 	if err != nil {
 		return internal.FailedResponseFromError(err), err
 	}


### PR DESCRIPTION
MOTIVATION
Few flex actions take a nodeName and can be performed everywhere in the
cluster. Those actions needs to do something on the corespongin VM in
oVirt and this means that the using ovirtVmId from the conf will not
work. For example Attach(volume, nodeName) can be called from the master
and not on the node.

MODIFICATION
Flex will query the api to get the node list and extract the systemUUID,
which is the VM id, by the nodeName. It is the equivalent of invoking
this from the cli:
```bash
oc get nodes/$(hostname) -o jsonpath="{.metadata.name} {.status.nodeInfo.systemUUID}"
```

RESULT
attach/detach/isAttached can be called from every node, to perform
action on every given node.

Fixes: #106