### PR TITLE
Add missing permissions to ovirt's user

### DIFF
--- a/docs/Creating-an-oVirt-user-how-to.md
+++ b/docs/Creating-an-oVirt-user-how-to.md
@@ -35,6 +35,13 @@ Here is a small playbook to create a user `'theAdmin`' in ovirt and grant it the
         object_type: data_center
         object_name: Default
 
+      - state: present
+        user_name: theAdmin
+        authz_name: internal-authz
+        role: UserVmManager
+        object_type: data_center
+        object_name: Default
+
   pre_tasks:
     - name: Login to oVirt
       ovirt_auth:


### PR DESCRIPTION
The designated user was missing the "Edit Storage" action group. Without it ovirt rejects the attach disk action.
One such role that includes this action group is "UserVmManager".

Fixes: #110
