### PR TITLE
Fixed StorageType for FibreChannel Storagedomain

### DIFF
--- a/internal/ovirt-mini-api.go
+++ b/internal/ovirt-mini-api.go
@@ -200,9 +200,9 @@ func (ovirt *Ovirt) DefaultDiskParamsBy(storageDomainName string, thinProvisione
 	}
 
 	// thin provisioned
-	// block (iscsi/fc)    - cow + sparse
+	// block (iscsi/fcp)    - cow + sparse
 	// file  (nfs/gluster) - raw + sparse
-	if domain.Storage.Type == "iscsi" || domain.Storage.Type == "fc" {
+	if domain.Storage.Type == "iscsi" || domain.Storage.Type == "fcp" {
 		return "cow", true, nil
 	}
 	return "raw", true, nil


### PR DESCRIPTION
ovirt-api: 
the Storage type for fibrechannel is fcp not fc see:
http://ovirt.github.io/ovirt-engine-api-model/4.2/#types/storage_type

MOTIVATION \
I am getting the Error:
2019-04-03 13:59:24,829+02 WARN  [org.ovirt.engine.core.bll.storage.disk.AddDiskCommand] (default task-19991) [bcf73cb0-3a27-447e-b093-0dc3bf0ff15e] Validation of action 'AddDisk' failed for user <user>-authz. Reasons: VAR__ACTION__ADD,VAR__TYPE__DISK,ACTION_TYPE_FAILED_DISK_CONFIGURATION_NOT_SUPPORTED,$volumeFormat RAW,$volumeType Sparse
2019-04-03 13:59:24,835+02 ERROR [org.ovirt.engine.api.restapi.resource.AbstractBackendResource] (default task-19991) [] Operation Failed: [Cannot add Virtual Disk. Disk configuration (RAW Sparse) is incompatible with the storage domain type.]

MODIFICATION \
fixed type, see api documentation

RESULT \
hope that fixes my problem?


