### PR TITLE
Produce smaller image for driver container

### DIFF
--- a/deployment/ovirt-flexvolume-driver/container/Dockerfile
+++ b/deployment/ovirt-flexvolume-driver/container/Dockerfile
@@ -30,13 +30,15 @@ WORKDIR /root/go/src/github.com/ovirt/ovirt-openshift-extensions
 ADD ovirt-openshift-extensions-$VERSION-$RELEASE.tar.gz .
 
 RUN yum install -y epel-release --enablerepo=extras && \
-    yum install -y --enablerepo=extras golang make &&  \
+    yum install -y --enablerepo=extras --disablerepo=updates golang make &&  \
+    make ovirt-flexvolume-driver && \
+    mv ovirt-flexvolume-driver /usr/bin/ && \
+    yum history -y rollback 2 && \ 
     yum clean all && rm -rf /var/cache/yum
 
 RUN make ovirt-flexvolume-driver
 
 #TODO use multi-stage when buildah runs in mock or docker 1.17 is available
-RUN cp -v ovirt-flexvolume-driver /usr/bin/
 RUN cp -v deployment/ovirt-flexvolume-driver/entrypoint.sh /
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/deployment/ovirt-flexvolume-driver/container/Dockerfile
+++ b/deployment/ovirt-flexvolume-driver/container/Dockerfile
@@ -36,7 +36,6 @@ RUN yum install -y epel-release --enablerepo=extras && \
     yum history -y rollback 2 && \ 
     yum clean all && rm -rf /var/cache/yum
 
-RUN make ovirt-flexvolume-driver
 
 #TODO use multi-stage when buildah runs in mock or docker 1.17 is available
 RUN cp -v deployment/ovirt-flexvolume-driver/entrypoint.sh /


### PR DESCRIPTION
Fix #134
Stream lining built image:
- No rpm already in the CentOS will be updated as part of dependency installation.
- Go source code is compiled after compiler installation and before removing compiler, all in a single container build step.
- Compiled binary is moved to target destination without leaving duplicate folder in previous build step.
