### PR TITLE
build: Support multi-stage container builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,13 +55,13 @@ container-%: tarball
 	docker build \
 		-t $(REGISTRY)/$*:$(VERSION_RELEASE) \
 		-t $(REGISTRY)/$*:latest \
-		--build-arg VERSION=$(VERSION) \
-		--build-arg RELEASE=$(RELEASE) \
+		--build-arg version=$(VERSION) \
+		--build-arg release=$(RELEASE) \
 		-f $(DOCKERFILE) \
 		$(DIR)
 
 container-push-%:
-	@docker login -u rgolangh -p ${QUAY_API_KEY} quay.io
+	@docker login -u rgolangh+ovirtci -p ${QUAY_API_KEY} quay.io
 	docker push $(REGISTRY)/$*:$(VERSION_RELEASE)
 ifneq ($(PUSH_LATEST),0)
 	docker push $(REGISTRY)/$*:latest

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ COMMON_ENV=CGO_ENABLED=0 GOOS=linux GOARCH=amd64
 COMMON_GO_BUILD_FLAGS=-ldflags '-extldflags "-static"'
 
 TARBALL=ovirt-openshift-extensions-$(VERSION_RELEASE).tar.gz
+PUSH_LATEST=1
 
 all: clean deps build test container container-push
 
@@ -62,7 +63,9 @@ container-%: tarball
 container-push-%:
 	@docker login -u rgolangh -p ${QUAY_API_KEY} quay.io
 	docker push $(REGISTRY)/$*:$(VERSION_RELEASE)
+ifneq ($(PUSH_LATEST),0)
 	docker push $(REGISTRY)/$*:latest
+endif
 	echo "$(REGISTRY)/$*:$(VERSION_RELEASE)" >> containers-artifacts.list
 
 build: $(binaries)

--- a/automation.yaml
+++ b/automation.yaml
@@ -1,4 +1,7 @@
 archs: 
   - x86_64
 distros:
-  - el7
+  - fc29 
+runtime-requirements:
+  support-nesting-level: 2
+  isolation_level: container

--- a/automation/build-artifacts.environment.yaml
+++ b/automation/build-artifacts.environment.yaml
@@ -1,9 +1,3 @@
-- name: 'DOCKER_BUILDER_API_KEY' 
-  valueFrom:
-    secretKeyRef:
-        name: 'docker_api_key'
-        key: 'key'
-
 - name: QUAY_API_KEY
   valueFrom:
     secretKeyRef:

--- a/automation/build-artifacts.packages
+++ b/automation/build-artifacts.packages
@@ -1,2 +1,2 @@
-docker
+docker-ce
 git

--- a/automation/build-artifacts.repos.fc29
+++ b/automation/build-artifacts.repos.fc29
@@ -1,0 +1,1 @@
+https://download.docker.com/linux/fedora/29/x86_64/stable

--- a/automation/build-artifacts.sh
+++ b/automation/build-artifacts.sh
@@ -4,7 +4,7 @@ EXPORTED_ARTIFACTS=exported-artifacts
 mkdir -p $EXPORTED_ARTIFACTS
 
 make build-containers ARTIFACT_DIR=$EXPORTED_ARTIFACTS
-make push-containers
+make push-containers PUSH_LATEST=$([ $(basename $0) == "build-artifacts.sh" ] && echo 0)
 make apb_build apb_docker_push
 
 cp containers-artifacts.list $EXPORTED_ARTIFACTS || true

--- a/automation/check-merged.repos.fc29
+++ b/automation/check-merged.repos.fc29
@@ -1,0 +1,1 @@
+build-artifacts.repos.fc29

--- a/automation/check-patch.repos.fc29
+++ b/automation/check-patch.repos.fc29
@@ -1,0 +1,1 @@
+build-artifacts.repos.fc29

--- a/automation/ci/Dockerfile
+++ b/automation/ci/Dockerfile
@@ -4,9 +4,6 @@ USER root
 RUN yum install -y \
 	http://resources.ovirt.org/pub/yum-repo/ovirt-release42.rpm	
 
-# Installing pre release of 4.2 till GA of 4.2.7 see github issues/73
-RUN yum install -y ovirt-release42-pre
-
 ARG PKGS='file python-ovirt-engine-sdk4 ovirt-ansible-roles'
 
 RUN yum install -y ${PKGS} && yum clean all && rm -rf /var/run/cache

--- a/automation/ci/Dockerfile
+++ b/automation/ci/Dockerfile
@@ -21,7 +21,7 @@ ADD setup_dns.yaml  setup_dns.yaml
 ADD flex_deployer_job.yaml flex_deployer_job.yaml
 
 ENV OPTS="-v "
-ENV ANSIBLE_ROLES_PATH="/usr/share/ansible/roles/"
+ENV ANSIBLE_ROLES_PATH="/usr/share/ansible/roles:/usr/share/ansible/openshift-ansible/roles/"
 ENV ANSIBLE_JINJA2_EXTENSIONS="jinja2.ext.do"
 ENV INVENTORY_FILE="integ.ini"
 ENV PLAYBOOK_FILE="install_okd.yaml"

--- a/automation/ci/vars.yaml
+++ b/automation/ci/vars.yaml
@@ -97,6 +97,8 @@ openshift_ovirt_vm_profile:
       custom_script: "{{ cloud_init_script_master | to_nice_yaml }}"
   node_vm:
     <<: *node_item
+  infra_vm:
+    <<: *node_item
   etcd_vm:
     <<: *node_item
   lb_vm:

--- a/deployment/ovirt-cloud-provider/container/Dockerfile
+++ b/deployment/ovirt-cloud-provider/container/Dockerfile
@@ -12,30 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM centos:7.6.1810
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.11 AS builder
 
-ARG VERSION
-ARG RELEASE
+ARG version
+ARG release
 
 LABEL   com.redhat.component="ovirt-openshift-extensions" \
         name="ovirt-cloud-provider" \
-        version="$VERSION" \
-        release="$RELEASE" \
+        version="$version" \
+        release="$release" \
         architecture="x86_64" \
         summary="ovirt-cloud-provider for openshift, for a deployment on top of ovirt" \
         maintainer="Roy Golan <rgolan@redhat.com>"
 
-RUN mkdir -p /root/go/src/github.com/ovirt/ovirt-openshift-extensions
-WORKDIR /root/go/src/github.com/ovirt/ovirt-openshift-extensions
-ADD ovirt-openshift-extensions-$VERSION-$RELEASE.tar.gz .
-
-RUN yum install -y epel-release --enablerepo=extras && \
-    yum install -y --enablerepo=extras golang make &&  \
-    yum clean all && rm -rf /var/cache/yum
+WORKDIR /go/src/github.com/ovirt/ovirt-openshift-extensions
+ADD ovirt-openshift-extensions-$version-$release.tar.gz .
 
 RUN make ovirt-cloud-provider
 
-#TODO use multi-stage when buildah runs in mock or docker 1.17 is available
-RUN cp -v ovirt-cloud-provider /usr/bin
+FROM registry.svc.ci.openshift.org/origin/4.1:base
+
+COPY --from=builder /go/src/github.com/ovirt/ovirt-openshift-extensions/ovirt-cloud-provider /usr/bin/
 
 ENTRYPOINT ["/usr/bin/ovirt-cloud-provider"]

--- a/deployment/ovirt-flexvolume-driver/container/Dockerfile
+++ b/deployment/ovirt-flexvolume-driver/container/Dockerfile
@@ -12,31 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM centos:7.6.1810
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.11 AS builder
 
-ARG VERSION
-ARG RELEASE
+ARG version 
+ARG release 
 
 LABEL   com.redhat.component="ovirt-openshift-extensions" \
         name="ovirt-flexvolume-driver" \
-        version="$VERSION" \
-        release="$RELEASE" \
+        version="$version" \
+        release="$release" \
         architecture="x86_64" \
         summary="ovirt-flexvolume-driver for openshift, for dynamic volume provisioning" \
         maintainer="Roy Golan <rgolan@redhat.com>"
 
-RUN mkdir -p /root/go/src/github.com/ovirt/ovirt-openshift-extensions
-WORKDIR /root/go/src/github.com/ovirt/ovirt-openshift-extensions
-ADD ovirt-openshift-extensions-$VERSION-$RELEASE.tar.gz .
-
-RUN yum install -y epel-release --enablerepo=extras && \
-    yum install -y --enablerepo=extras golang make &&  \
-    yum clean all && rm -rf /var/cache/yum
+WORKDIR /go/src/github.com/ovirt/ovirt-openshift-extensions
+ADD ovirt-openshift-extensions-$version-$release.tar.gz .
 
 RUN make ovirt-flexvolume-driver
 
-#TODO use multi-stage when buildah runs in mock or docker 1.17 is available
-RUN cp -v ovirt-flexvolume-driver /usr/bin/
-RUN cp -v deployment/ovirt-flexvolume-driver/entrypoint.sh /
+FROM registry.svc.ci.openshift.org/origin/4.1:base
+
+COPY --from=builder /go/src/github.com/ovirt/ovirt-openshift-extensions/ovirt-flexvolume-driver /usr/bin/
+COPY --from=builder /go/src/github.com/ovirt/ovirt-openshift-extensions/deployment/ovirt-flexvolume-driver/entrypoint.sh /
+COPY --from=builder /tmp/coverage.html /tmp/coverage.html
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/deployment/ovirt-volume-provisioner/container/Dockerfile
+++ b/deployment/ovirt-volume-provisioner/container/Dockerfile
@@ -12,30 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM centos:7.6.1810
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.11 AS builder
 
-ARG VERSION
-ARG RELEASE
+ARG version 
+ARG release
 
 LABEL   com.redhat.component="ovirt-openshift-extensions" \
         name="ovirt-volume-provisioner" \
-        version="$VERSION" \
-        release="$RELEASE" \
+        version="$version" \
+        release="$release" \
         architecture="x86_64" \
         summary="ovirt-volume-provisioner for openshift, for dynamic volume provisioning" \
         maintainer="Roy Golan <rgolan@redhat.com>"
 
-RUN mkdir -p /root/go/src/github.com/ovirt/ovirt-openshift-extensions
-WORKDIR /root/go/src/github.com/ovirt/ovirt-openshift-extensions
-ADD ovirt-openshift-extensions-$VERSION-$RELEASE.tar.gz .
-
-RUN yum install -y epel-release --enablerepo=extras && \
-    yum install -y --enablerepo=extras golang make &&  \
-    yum clean all && rm -rf /var/cache/yum
+WORKDIR /go/src/github.com/ovirt/ovirt-openshift-extensions
+ADD ovirt-openshift-extensions-$version-$release.tar.gz .
 
 RUN make ovirt-volume-provisioner
 
-#TODO use multi-stage when buildah runs in mock or docker 1.17 is available
-RUN cp -v ovirt-volume-provisioner /usr/bin
+FROM registry.svc.ci.openshift.org/origin/4.1:base
+
+COPY --from=builder /go/src/github.com/ovirt/ovirt-openshift-extensions/ovirt-volume-provisioner /usr/bin/
 
 ENTRYPOINT ["/usr/bin/ovirt-volume-provisioner"]


### PR DESCRIPTION
build: support multi-stage builds

Motivation
Publish smaller containers, less time to download, less time to
build, less CVEs, less deps

Modification
Use multi-stage syntax in Dockerfiles - requires docker >=
17.05 Tweak the automation.yaml to run on hosts that has the proper docker 
version

Result
Smaller containers

