### PR TITLE
Distribute the container using RHEL 8 UBI

### DIFF
--- a/deployment/ovirt-cloud-provider/container/Dockerfile
+++ b/deployment/ovirt-cloud-provider/container/Dockerfile
@@ -30,7 +30,7 @@ ADD ovirt-openshift-extensions-$version-$release.tar.gz .
 
 RUN make ovirt-cloud-provider
 
-FROM registry.svc.ci.openshift.org/origin/4.1:base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 
 COPY --from=builder /go/src/github.com/ovirt/ovirt-openshift-extensions/ovirt-cloud-provider /usr/bin/
 

--- a/deployment/ovirt-flexvolume-driver/container/Dockerfile
+++ b/deployment/ovirt-flexvolume-driver/container/Dockerfile
@@ -30,7 +30,7 @@ ADD ovirt-openshift-extensions-$version-$release.tar.gz .
 
 RUN make ovirt-flexvolume-driver
 
-FROM registry.svc.ci.openshift.org/origin/4.1:base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 
 COPY --from=builder /go/src/github.com/ovirt/ovirt-openshift-extensions/ovirt-flexvolume-driver /usr/bin/
 COPY --from=builder /go/src/github.com/ovirt/ovirt-openshift-extensions/deployment/ovirt-flexvolume-driver/entrypoint.sh /

--- a/deployment/ovirt-volume-provisioner/container/Dockerfile
+++ b/deployment/ovirt-volume-provisioner/container/Dockerfile
@@ -30,7 +30,7 @@ ADD ovirt-openshift-extensions-$version-$release.tar.gz .
 
 RUN make ovirt-volume-provisioner
 
-FROM registry.svc.ci.openshift.org/origin/4.1:base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 
 COPY --from=builder /go/src/github.com/ovirt/ovirt-openshift-extensions/ovirt-volume-provisioner /usr/bin/
 


### PR DESCRIPTION
Rebuild and disttribute all the containers using the universal base image, a free
redistributable container image, based on RHEL 8. 
Read here for more details - https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/building_running_and_managing_containers/index

MOTIVATION \
More secure, thinner, more updated base images for the containers, based on RHEL 8

MODIFICATION \
Rebuild the containers using ubi8/ubi-minimal

RESULT
Images have 0 security issues - see Red Hat's container image health index  https://access.redhat.com/containers/?tab=overview#/registry.access.redhat.com/ubi8-minimal
Images are smaller - Red Hat's page says its currently 32.5 Mb (quay shows ~40-50 mb for the final image of ovirt-storage-provisioner)
Build is faster, shorter dev/qe cycles